### PR TITLE
GitHub auth provider fixes

### DIFF
--- a/providers/github/github_provider.go
+++ b/providers/github/github_provider.go
@@ -266,3 +266,16 @@ func (g *GProvider) GetLegacySettings() map[string]string {
 	settings["allowedIdentitiesSetting"] = githubAllowedIdentitiesSetting
 	return settings
 }
+
+//GetRedirectURL returns the provider specific redirect URL used by UI
+func (g *GProvider) GetRedirectURL() string {
+	redirect := ""
+	if g.githubClient.config.Hostname != "" {
+		redirect = g.githubClient.config.Scheme + g.githubClient.config.Hostname
+	} else {
+		redirect = githubDefaultHostName
+	}
+	redirect = redirect + "/login/oauth/authorize?clientId=" + g.githubClient.config.ClientID + "&scope=read:org"
+
+	return redirect
+}

--- a/providers/github/github_provider.go
+++ b/providers/github/github_provider.go
@@ -200,9 +200,6 @@ func (g *GProvider) SearchIdentities(name string, exactMatch bool, accessToken s
 //LoadConfig initializes the provider with the passes config
 func (g *GProvider) LoadConfig(authConfig model.AuthConfig) error {
 	configObj := authConfig.GithubConfig
-	if configObj.ClientID == "" || configObj.ClientSecret == "" {
-		return fmt.Errorf("Missing ClientID or ClientSecret in githubConfig")
-	}
 	g.githubClient.config = &configObj
 	return nil
 }

--- a/providers/identity_provider.go
+++ b/providers/identity_provider.go
@@ -21,6 +21,7 @@ type IdentityProvider interface {
 	GetProviderSettingList() []string
 	AddProviderConfig(authConfig *model.AuthConfig, providerSettings map[string]string)
 	GetLegacySettings() map[string]string
+	GetRedirectURL() string
 }
 
 //GetProvider returns an instance of an identyityProvider by name

--- a/server/auth_server.go
+++ b/server/auth_server.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	log "github.com/Sirupsen/logrus"
 	"github.com/urfave/cli"
+	"net/url"
 	"strconv"
 	"strings"
 
@@ -455,4 +456,29 @@ func SearchIdentities(name string, exactMatch bool, accessToken string) ([]clien
 		return provider.SearchIdentities(name, exactMatch, accessToken)
 	}
 	return []client.Identity{}, fmt.Errorf("No auth provider configured")
+}
+
+//GetRedirectURL returns the redirect URL for the provider if applicable
+func GetRedirectURL() (map[string]string, error) {
+	response := make(map[string]string)
+	if provider != nil {
+		redirect := provider.GetRedirectURL()
+		response["redirectUrl"] = URLEncoded(redirect)
+		response["provider"] = provider.GetName()
+		log.Debugf("GetRedirectURL: returning response %v", response)
+		return response, nil
+	}
+	return response, fmt.Errorf("No auth provider configured")
+}
+
+//URLEncoded escape url query
+func URLEncoded(str string) string {
+	u, err := url.Parse(str)
+	if err != nil {
+		log.Errorf("Error encoding the url: %s , error: %v", str, err)
+		return str
+	}
+
+	u.RawQuery = u.Query().Encode()
+	return u.String()
 }

--- a/server/auth_server.go
+++ b/server/auth_server.go
@@ -181,7 +181,8 @@ func getAllowedIDString(allowedIdentities []client.Identity) string {
 	if len(allowedIdentities) > 0 {
 		var idArray []string
 		for _, identity := range allowedIdentities {
-			idArray = append(idArray, identity.Id)
+			identityID := identity.ExternalIdType + ":" + identity.ExternalId
+			idArray = append(idArray, identityID)
 		}
 		return strings.Join(idArray, ",")
 	}

--- a/service/route_handlers.go
+++ b/service/route_handlers.go
@@ -209,3 +209,16 @@ func Reload(w http.ResponseWriter, r *http.Request) {
 		ReturnHTTPError(w, r, http.StatusInternalServerError, "Failed to reload the auth config")
 	}
 }
+
+//GetRedirectURL gets the redirect URL
+func GetRedirectURL(w http.ResponseWriter, r *http.Request) {
+	redirectResponse, err := server.GetRedirectURL()
+	if err == nil {
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(redirectResponse)
+	} else {
+		//failed to get the redirectURL
+		log.Debugf("GetRedirectUrl failed with error %v", err)
+		ReturnHTTPError(w, r, http.StatusInternalServerError, "Failed to get the redirect URL")
+	}
+}

--- a/service/routes.go
+++ b/service/routes.go
@@ -73,6 +73,7 @@ func NewRouter() *mux.Router {
 	router.Methods("POST").Path("/v1-auth/token").Handler(api.ApiHandler(schemas, http.HandlerFunc(CreateToken)))
 	router.Methods("GET").Path("/v1-auth/me/identities").Handler(api.ApiHandler(schemas, http.HandlerFunc(GetIdentities)))
 	router.Methods("GET").Path("/v1-auth/identities").Handler(api.ApiHandler(schemas, http.HandlerFunc(SearchIdentities)))
+	router.Methods("GET").Path("/v1-auth/redirectUrl").Handler(api.ApiHandler(schemas, http.HandlerFunc(GetRedirectURL)))
 
 	return router
 }

--- a/service/routes.go
+++ b/service/routes.go
@@ -1,12 +1,12 @@
 package service
 
 import (
-	"net/http"
-	"strconv"
 	"github.com/gorilla/mux"
 	"github.com/rancher/go-rancher/api"
 	"github.com/rancher/go-rancher/client"
 	"github.com/rancher/rancher-auth-service/model"
+	"net/http"
+	"strconv"
 )
 
 //Route defines the properties of a go mux http route


### PR DESCRIPTION
1) Github UpdateConfig: Do not error if clientId/Secret are missing
2) Form the id for each identity using externalIdType and externalId
3) Implement the GET /redirectUrl API
