### PR TITLE
The redirectUrl for github should use "client_id" as the query parameter. Also set "enabled" setting last.

### DIFF
--- a/providers/github/github_provider.go
+++ b/providers/github/github_provider.go
@@ -275,7 +275,7 @@ func (g *GProvider) GetRedirectURL() string {
 	} else {
 		redirect = githubDefaultHostName
 	}
-	redirect = redirect + "/login/oauth/authorize?clientId=" + g.githubClient.config.ClientID + "&scope=read:org"
+	redirect = redirect + "/login/oauth/authorize?client_id=" + g.githubClient.config.ClientID + "&scope=read:org"
 
 	return redirect
 }

--- a/server/auth_server.go
+++ b/server/auth_server.go
@@ -240,15 +240,23 @@ func UpdateConfig(authConfig model.AuthConfig) error {
 	providerSettings[accessModeSetting] = authConfig.AccessMode
 	providerSettings[userTypeSetting] = newProvider.GetUserType()
 	providerSettings[allowedIdentitiesSetting] = getAllowedIDString(authConfig.AllowedIdentities)
-	providerSettings[securitySetting] = strconv.FormatBool(authConfig.Enabled)
 	providerSettings[providerNameSetting] = authConfig.Provider
 	providerSettings[providerSetting] = authConfig.Provider
 	providerSettings[externalProviderSetting] = "true"
 	err = updateSettings(providerSettings)
 	if err != nil {
-		log.Errorf("Error Storing the provider settings %v", err)
+		log.Errorf("UpdateConfig: Error Storing the provider settings %v", err)
 		return err
 	}
+	//set the security setting last specifically
+	providerSettings := make(map[string]string)
+	providerSettings[securitySetting] = strconv.FormatBool(authConfig.Enabled)
+	err = updateSettings(providerSettings)
+	if err != nil {
+		log.Errorf("UpdateConfig: Error Storing the provider security setting %v", err)
+		return err
+	}
+
 	//switch the in-memory provider
 	provider = newProvider
 	authConfigInMemory = authConfig


### PR DESCRIPTION
The redirectUrl for github should use "client_id" as the query parameter instead of "clientId"

Also set the "enabled" setting at last during updateConfig API, so that
any error is config does not left the system with auth turned ON.
