### PR TITLE
Revert "disable cgo"

### DIFF
--- a/scripts/build
+++ b/scripts/build
@@ -7,4 +7,4 @@ cd $(dirname $0)/..
 
 mkdir -p bin
 [ "$(uname)" != "Darwin" ] && LINKFLAGS="-extldflags -static -s"
-CGO_ENABLED=0 go build -tags static -ldflags "-X main.VERSION=$VERSION $LINKFLAGS" -o bin/rancher-auth-service
+go build -tags static -ldflags "-X main.VERSION=$VERSION $LINKFLAGS" -o bin/rancher-auth-service


### PR DESCRIPTION
Reverts rancher/rancher-auth-service#8
The saml package has dependencies on an xml package that has a package on dynamically linked libraries for libxml.

See https://github.com/crewjam/go-xmlsec