### PR TITLE
Changes to set the loglevel as per the setting 'auth.service.log.level'

### DIFF
--- a/server/auth_server.go
+++ b/server/auth_server.go
@@ -29,6 +29,7 @@ const (
 	securitySetting          = "api.security.enabled"
 	apiHostSetting           = "api.host"
 	identitySeparatorSetting = "api.auth.external.provider.identity.separator"
+	authServiceLogSetting    = "auth.service.log.level"
 )
 
 var (
@@ -380,12 +381,33 @@ func GetConfig(accessToken string, listOnly bool) (model.AuthConfig, error) {
 	settings = append(settings, securitySetting)
 	settings = append(settings, providerSetting)
 	settings = append(settings, providerNameSetting)
+	settings = append(settings, authServiceLogSetting)
 
 	dbSettings, err := readSettings(settings)
 	if err != nil {
 		log.Errorf("GetConfig: Error reading DB settings %v", err)
 		return config, err
 	}
+
+	if dbSettings[authServiceLogSetting] != "" {
+		switch strings.ToLower(dbSettings[authServiceLogSetting]) {
+		case "trace":
+			log.SetLevel(log.DebugLevel)
+		case "debug":
+			log.SetLevel(log.DebugLevel)
+		case "info":
+			log.SetLevel(log.InfoLevel)
+		case "warn":
+			log.SetLevel(log.WarnLevel)
+		case "error":
+			log.SetLevel(log.ErrorLevel)
+		case "fatal":
+			log.SetLevel(log.FatalLevel)
+		case "panic":
+			log.SetLevel(log.PanicLevel)
+		}
+	}
+
 	config.AccessMode = dbSettings[accessModeSetting]
 
 	enabled, err := strconv.ParseBool(dbSettings[securitySetting])


### PR DESCRIPTION
Changes to set the loglevel as per the setting 'auth.service.log.level' during server startup and reload

This also needs the Cattle PR https://github.com/rancher/cattle/pull/2838

https://github.com/rancher/rancher/issues/9390