### PR TITLE
Add accessToken to ldap

### DIFF
--- a/providers/ldap/ldap_client.go
+++ b/providers/ldap/ldap_client.go
@@ -650,7 +650,7 @@ func (l *LClient) RefreshToken(json map[string]string) (model.Token, int, error)
 	c := l.ConstantsConfig
 	searchConfig := l.SearchConfig
 	query := "(" + c.ObjectClassAttribute + "=*)"
-	search := ldap.NewSearchRequest(json["externalId"],
+	search := ldap.NewSearchRequest(json["accessToken"],
 		ldap.ScopeWholeSubtree, ldap.NeverDerefAliases, 0, 0, false,
 		query,
 		searchConfig.UserSearchAttributes, nil)
@@ -698,7 +698,6 @@ func (l *LClient) userRecord(search *ldap.SearchRequest, lConn *ldap.Conn) (mode
 	var token = model.Token{Resource: client.Resource{
 		Type: "token",
 	}}
-	token.AccessToken = ""
 	token.IdentityList = identityList
 	token.Type = c.LdapJwt
 	userIdentity, ok := GetUserIdentity(identityList, c.UserScope)
@@ -706,5 +705,6 @@ func (l *LClient) userRecord(search *ldap.SearchRequest, lConn *ldap.Conn) (mode
 		return nilToken, status, fmt.Errorf("User identity not found for Ldap")
 	}
 	token.ExternalAccountID = userIdentity.ExternalId
+	token.AccessToken = userIdentity.ExternalId
 	return token, status, nil
 }

--- a/service/route_handlers.go
+++ b/service/route_handlers.go
@@ -38,7 +38,6 @@ func CreateToken(w http.ResponseWriter, r *http.Request) {
 
 	securityCode := jsonInput["code"]
 	accessToken := jsonInput["accessToken"]
-	externalID := jsonInput["externalId"]
 
 	if securityCode != "" {
 		log.Debugf("CreateToken called with securityCode %s", securityCode)
@@ -53,7 +52,7 @@ func CreateToken(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 		api.GetApiContext(r).Write(&token)
-	} else if accessToken != "" || externalID != "" {
+	} else if accessToken != "" {
 		log.Debugf("RefreshToken called with accessToken %s", accessToken)
 		//getToken
 		token, status, err := server.RefreshToken(jsonInput)


### PR DESCRIPTION
Since ldap didn't have accessToken like github does, getAllowedIdentities from server.go was not calling ldap's GetIdentity code, because accessToken was null. Ldap now sets the token's accessToken to the user's externalId, so `getAllowedIdentities` doesn't receive an empty access token