### PR TITLE
Returning the status codes from TestLogin API

### DIFF
--- a/providers/github/github_provider.go
+++ b/providers/github/github_provider.go
@@ -304,8 +304,8 @@ func (g *GProvider) GetIdentitySeparator() string {
 	return ","
 }
 
-func (g *GProvider) TestLogin(testAuthConfig *model.TestAuthConfig) error {
-	return nil
+func (g *GProvider) TestLogin(testAuthConfig *model.TestAuthConfig) (int, error) {
+	return 0, nil
 }
 
 func (g *GProvider) GetProviderConfigResource() interface{} {

--- a/providers/identity_provider.go
+++ b/providers/identity_provider.go
@@ -34,7 +34,7 @@ type IdentityProvider interface {
 	GetLegacySettings() map[string]string
 	GetRedirectURL() string
 	GetIdentitySeparator() string
-	TestLogin(testAuthConfig *model.TestAuthConfig) error
+	TestLogin(testAuthConfig *model.TestAuthConfig) (int, error)
 	GetProviderConfigResource() interface{}
 	CustomizeSchema(schema *v1client.Schema) *v1client.Schema
 	GetProviderSecretSettings() []string

--- a/providers/ldap/ad/ad_provider.go
+++ b/providers/ldap/ad/ad_provider.go
@@ -269,7 +269,7 @@ func (a *ADProvider) GetRedirectURL() string {
 	return ""
 }
 
-func (a *ADProvider) TestLogin(testAuthConfig *model.TestAuthConfig) error {
+func (a *ADProvider) TestLogin(testAuthConfig *model.TestAuthConfig) (int, error) {
 	return a.LdapClient.TestLogin(testAuthConfig)
 }
 

--- a/providers/shibboleth/shibboleth_provider.go
+++ b/providers/shibboleth/shibboleth_provider.go
@@ -275,8 +275,8 @@ func (s *SProvider) GetIdentitySeparator() string {
 	return "#shibsaml#"
 }
 
-func (s *SProvider) TestLogin(testAuthConfig *model.TestAuthConfig) error {
-	return nil
+func (s *SProvider) TestLogin(testAuthConfig *model.TestAuthConfig) (int, error) {
+	return 0, nil
 }
 
 func (s *SProvider) GetProviderConfigResource() interface{} {

--- a/server/auth_server.go
+++ b/server/auth_server.go
@@ -1045,19 +1045,19 @@ func IsSamlJWTValid(value string) (bool, map[string][]string) {
 	return false, samlData
 }
 
-func TestLogin(testAuthConfig model.TestAuthConfig) error {
+func TestLogin(testAuthConfig model.TestAuthConfig) (int, error) {
 	authConfig := testAuthConfig.AuthConfig
 	newProvider, err := initProviderWithConfig(&authConfig)
 	if err != nil {
 		log.Errorf("GetProvider: Error initializing the provider %v", err)
-		return err
+		return 0, err
 	}
 
 	log.Infof("newProvider %v", newProvider.GetName())
-	err = newProvider.TestLogin(&testAuthConfig)
+	status, err := newProvider.TestLogin(&testAuthConfig)
 	if err != nil {
 		log.Errorf("GetProvider: Error in login %v", err)
-		return err
+		return status, err
 	}
-	return nil
+	return 0, nil
 }

--- a/service/route_handlers.go
+++ b/service/route_handlers.go
@@ -431,9 +431,12 @@ func TestLogin(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	err = server.TestLogin(testAuthConfig)
+	status, err := server.TestLogin(testAuthConfig)
 	if err != nil {
 		log.Errorf("TestLogin GetProvider failed with error: %v", err)
-		ReturnHTTPError(w, r, http.StatusUnauthorized, "Unauthorized, invalid credentials")
+		if status == 0 {
+			status = http.StatusInternalServerError
+		}
+		ReturnHTTPError(w, r, status, fmt.Sprintf("%v", err))
 	}
 }


### PR DESCRIPTION
API /v1-auth/testlogin was always returning a 401, now returning the error
based status codes.

https://github.com/rancher/rancher/issues/9462