### PR TITLE
Keep secret settings during update

### DIFF
--- a/providers/github/github_provider.go
+++ b/providers/github/github_provider.go
@@ -315,3 +315,9 @@ func (g *GProvider) GetProviderConfigResource() interface{} {
 func (g *GProvider) CustomizeSchema(schema *v1client.Schema) *v1client.Schema {
 	return schema
 }
+
+func (g *GProvider) GetProviderSecretSettings() []string {
+	var settings []string
+	settings = append(settings, clientSecretSetting)
+	return settings
+}

--- a/providers/identity_provider.go
+++ b/providers/identity_provider.go
@@ -37,6 +37,7 @@ type IdentityProvider interface {
 	TestLogin(testAuthConfig *model.TestAuthConfig) error
 	GetProviderConfigResource() interface{}
 	CustomizeSchema(schema *v1client.Schema) *v1client.Schema
+	GetProviderSecretSettings() []string
 }
 
 //GetProvider returns an instance of an identyityProvider by name

--- a/providers/ldap/ad/ad_provider.go
+++ b/providers/ldap/ad/ad_provider.go
@@ -333,6 +333,12 @@ func (a *ADProvider) CustomizeSchema(schema *v1client.Schema) *v1client.Schema {
 	return schema
 }
 
+func (a *ADProvider) GetProviderSecretSettings() []string {
+	var settings []string
+	settings = append(settings, ServiceAccountPasswordSetting)
+	return settings
+}
+
 func getAllowedIDString(allowedIdentities []client.Identity, separator string) string {
 	if len(allowedIdentities) > 0 {
 		var idArray []string

--- a/providers/shibboleth/shibboleth_provider.go
+++ b/providers/shibboleth/shibboleth_provider.go
@@ -286,3 +286,10 @@ func (s *SProvider) GetProviderConfigResource() interface{} {
 func (s *SProvider) CustomizeSchema(schema *v1client.Schema) *v1client.Schema {
 	return schema
 }
+
+func (s *SProvider) GetProviderSecretSettings() []string {
+	var settings []string
+	settings = append(settings, spSelfSignedKeySetting)
+	settings = append(settings, idpMetadataContentSetting)
+	return settings
+}


### PR DESCRIPTION
After GetConfig returns settings based on listOnly, call to updateSettings might not contain the secret values.
This means that the genericObject will get updated by updateSettings without the secret values. So provider won't get these values on next update.
This commit prevents secret settings from getting removed during update