### PR TITLE
Save lookup setting in plaintext

### DIFF
--- a/providers/github/github_provider.go
+++ b/providers/github/github_provider.go
@@ -321,3 +321,7 @@ func (g *GProvider) GetProviderSecretSettings() []string {
 	settings = append(settings, clientSecretSetting)
 	return settings
 }
+
+func (g *GProvider) IsIdentityLookupSupported() bool {
+	return true
+}

--- a/providers/identity_provider.go
+++ b/providers/identity_provider.go
@@ -38,6 +38,7 @@ type IdentityProvider interface {
 	GetProviderConfigResource() interface{}
 	CustomizeSchema(schema *v1client.Schema) *v1client.Schema
 	GetProviderSecretSettings() []string
+	IsIdentityLookupSupported() bool
 }
 
 //GetProvider returns an instance of an identyityProvider by name

--- a/providers/ldap/ad/ad_provider.go
+++ b/providers/ldap/ad/ad_provider.go
@@ -350,3 +350,7 @@ func getAllowedIDString(allowedIdentities []client.Identity, separator string) s
 	}
 	return ""
 }
+
+func (a *ADProvider) IsIdentityLookupSupported() bool {
+	return true
+}

--- a/providers/shibboleth/shibboleth_provider.go
+++ b/providers/shibboleth/shibboleth_provider.go
@@ -12,20 +12,19 @@ import (
 
 //Constants for shibboleth
 const (
-	Name                             = "shibboleth"
-	Config                           = Name + "config"
-	TokenType                        = Name + "jwt"
-	UserType                         = Name + "_user"
-	GroupType                        = Name + "_group"
-	idpMetadataURLSetting            = "api.auth.shibboleth.idp.metadata.url"
-	spSelfSignedCertSetting          = "api.auth.shibboleth.sp.self.signed.cert"
-	spSelfSignedKeySetting           = "api.auth.shibboleth.sp.self.signed.key"
-	groupsFieldSetting               = "api.auth.shibboleth.groups.field"
-	displayNameSetting               = "api.auth.shibboleth.displayname.field"
-	userNameSetting                  = "api.auth.shibboleth.username.field"
-	uidSetting                       = "api.auth.shibboleth.object.uid.field"
-	idpMetadataContentSetting        = "api.auth.shibboleth.idp.metadata.content"
-	noIdentityLookupSupportedSetting = "api.auth.external.provider.no.identity.lookup"
+	Name                      = "shibboleth"
+	Config                    = Name + "config"
+	TokenType                 = Name + "jwt"
+	UserType                  = Name + "_user"
+	GroupType                 = Name + "_group"
+	idpMetadataURLSetting     = "api.auth.shibboleth.idp.metadata.url"
+	spSelfSignedCertSetting   = "api.auth.shibboleth.sp.self.signed.cert"
+	spSelfSignedKeySetting    = "api.auth.shibboleth.sp.self.signed.key"
+	groupsFieldSetting        = "api.auth.shibboleth.groups.field"
+	displayNameSetting        = "api.auth.shibboleth.displayname.field"
+	userNameSetting           = "api.auth.shibboleth.username.field"
+	uidSetting                = "api.auth.shibboleth.object.uid.field"
+	idpMetadataContentSetting = "api.auth.shibboleth.idp.metadata.content"
 )
 
 func init() {
@@ -217,7 +216,6 @@ func (s *SProvider) GetSettings() map[string]string {
 	if s.shibClient.config.IDPMetadataContent != "" {
 		settings[idpMetadataContentSetting] = s.shibClient.config.IDPMetadataContent
 	}
-	settings[noIdentityLookupSupportedSetting] = "true"
 
 	return settings
 }
@@ -231,7 +229,6 @@ func (s *SProvider) GetProviderSettingList(listOnly bool) []string {
 	settings = append(settings, displayNameSetting)
 	settings = append(settings, userNameSetting)
 	settings = append(settings, uidSetting)
-	settings = append(settings, noIdentityLookupSupportedSetting)
 	if !listOnly {
 		settings = append(settings, spSelfSignedKeySetting)
 		settings = append(settings, idpMetadataContentSetting)
@@ -292,4 +289,8 @@ func (s *SProvider) GetProviderSecretSettings() []string {
 	settings = append(settings, spSelfSignedKeySetting)
 	settings = append(settings, idpMetadataContentSetting)
 	return settings
+}
+
+func (s *SProvider) IsIdentityLookupSupported() bool {
+	return false
 }

--- a/server/auth_server.go
+++ b/server/auth_server.go
@@ -37,6 +37,7 @@ const (
 	identitySeparatorSetting         = "api.auth.external.provider.identity.separator"
 	authServiceLogSetting            = "auth.service.log.level"
 	authServiceConfigUpdateTimestamp = "auth.service.config.update.timestamp"
+	noIdentityLookupSupportedSetting = "api.auth.external.provider.no.identity.lookup"
 )
 
 var (
@@ -517,6 +518,7 @@ func UpdateConfig(authConfig model.AuthConfig) error {
 	commonSettings[providerNameSetting] = authConfig.Provider
 	commonSettings[providerSetting] = authConfig.Provider
 	commonSettings[externalProviderSetting] = "true"
+	commonSettings[noIdentityLookupSupportedSetting] = strconv.FormatBool(!newProvider.IsIdentityLookupSupported())
 	err = updateCommonSettings(commonSettings)
 	if err != nil {
 		return errors.Wrap(err, "UpdateConfig: Error Storing the common settings")
@@ -601,6 +603,7 @@ func UpgradeSettings() error {
 			commonSettings[allowedIdentitiesSetting] = dbLegacySettings[legacySettingsMap["allowedIdentitiesSetting"]]
 			commonSettings[providerNameSetting] = providerNameInDb
 			commonSettings[externalProviderSetting] = "true"
+			commonSettings[noIdentityLookupSupportedSetting] = strconv.FormatBool(!newProvider.IsIdentityLookupSupported())
 
 			err = updateCommonSettings(commonSettings)
 			if err != nil {


### PR DESCRIPTION
Identity lookup supported setting is common to all providers. This commit removes it from shibboleth provider and saves it with all common settings