### PR TITLE
SA user bind when enabling auth

### DIFF
--- a/providers/ldap/ad/ad_provider.go
+++ b/providers/ldap/ad/ad_provider.go
@@ -248,6 +248,7 @@ func (a *ADProvider) LoadConfig(authConfig *model.AuthConfig) error {
 	a.LdapClient.AllowedIdentities = getAllowedIDString(authConfig.AllowedIdentities, a.GetIdentitySeparator())
 	a.LdapClient.ConstantsConfig = adConstantsConfig
 	a.LdapClient.SearchConfig = a.LdapClient.InitializeSearchConfig()
+	a.LdapClient.Enabled = authConfig.Enabled
 	return nil
 }
 


### PR DESCRIPTION
Service account user bind should take place when generating token only if auth
is not enabled.