### PR TITLE
Checks for testlogin API to ensure no AD server change is done

### DIFF
--- a/providers/github/github_provider.go
+++ b/providers/github/github_provider.go
@@ -304,7 +304,7 @@ func (g *GProvider) GetIdentitySeparator() string {
 	return ","
 }
 
-func (g *GProvider) TestLogin(testAuthConfig *model.TestAuthConfig) (int, error) {
+func (g *GProvider) TestLogin(testAuthConfig *model.TestAuthConfig, accessToken string) (int, error) {
 	return 0, nil
 }
 

--- a/providers/identity_provider.go
+++ b/providers/identity_provider.go
@@ -34,7 +34,7 @@ type IdentityProvider interface {
 	GetLegacySettings() map[string]string
 	GetRedirectURL() string
 	GetIdentitySeparator() string
-	TestLogin(testAuthConfig *model.TestAuthConfig) (int, error)
+	TestLogin(testAuthConfig *model.TestAuthConfig, accessToken string) (int, error)
 	GetProviderConfigResource() interface{}
 	CustomizeSchema(schema *v1client.Schema) *v1client.Schema
 	GetProviderSecretSettings() []string

--- a/providers/ldap/ad/ad_provider.go
+++ b/providers/ldap/ad/ad_provider.go
@@ -270,8 +270,8 @@ func (a *ADProvider) GetRedirectURL() string {
 	return ""
 }
 
-func (a *ADProvider) TestLogin(testAuthConfig *model.TestAuthConfig) (int, error) {
-	return a.LdapClient.TestLogin(testAuthConfig)
+func (a *ADProvider) TestLogin(testAuthConfig *model.TestAuthConfig, accessToken string) (int, error) {
+	return a.LdapClient.TestLogin(testAuthConfig, accessToken)
 }
 
 func (a *ADProvider) GetProviderConfigResource() interface{} {

--- a/providers/shibboleth/shibboleth_provider.go
+++ b/providers/shibboleth/shibboleth_provider.go
@@ -272,7 +272,7 @@ func (s *SProvider) GetIdentitySeparator() string {
 	return "#shibsaml#"
 }
 
-func (s *SProvider) TestLogin(testAuthConfig *model.TestAuthConfig) (int, error) {
+func (s *SProvider) TestLogin(testAuthConfig *model.TestAuthConfig, accessToken string) (int, error) {
 	return 0, nil
 }
 

--- a/server/auth_server.go
+++ b/server/auth_server.go
@@ -1058,7 +1058,7 @@ func IsSamlJWTValid(value string) (bool, map[string][]string) {
 	return false, samlData
 }
 
-func TestLogin(testAuthConfig model.TestAuthConfig) (int, error) {
+func TestLogin(testAuthConfig model.TestAuthConfig, accessToken string) (int, error) {
 	authConfig := testAuthConfig.AuthConfig
 	newProvider, err := initProviderWithConfig(&authConfig)
 	if err != nil {
@@ -1067,7 +1067,7 @@ func TestLogin(testAuthConfig model.TestAuthConfig) (int, error) {
 	}
 
 	log.Infof("newProvider %v", newProvider.GetName())
-	status, err := newProvider.TestLogin(&testAuthConfig)
+	status, err := newProvider.TestLogin(&testAuthConfig, accessToken)
 	if err != nil {
 		log.Errorf("GetProvider: Error in login %v", err)
 		return status, err

--- a/service/route_handlers.go
+++ b/service/route_handlers.go
@@ -40,7 +40,7 @@ func CreateToken(w http.ResponseWriter, r *http.Request) {
 	accessToken := jsonInput["accessToken"]
 
 	if securityCode != "" {
-		log.Debugf("CreateToken called with securityCode %s", securityCode)
+		log.Debugf("CreateToken called with securityCode")
 		//getToken
 		token, status, err := server.CreateToken(jsonInput)
 		if err != nil {
@@ -410,6 +410,19 @@ func DoSamlLogout(w http.ResponseWriter, r *http.Request) {
 
 // TestLogin is a test API to check login with code before saving settings to db
 func TestLogin(w http.ResponseWriter, r *http.Request) {
+
+	authHeader := r.Header.Get("Authorization")
+	var accessToken string
+	// header value format will be "Bearer <token>"
+	if authHeader != "" {
+		if !strings.HasPrefix(authHeader, "Bearer ") {
+			log.Errorf("GetMyIdentities Failed to find Bearer token %v", authHeader)
+			ReturnHTTPError(w, r, http.StatusUnauthorized, "Unauthorized, please provide a valid token")
+			return
+		}
+		accessToken = strings.TrimPrefix(authHeader, "Bearer ")
+	}
+
 	bytes, err := ioutil.ReadAll(r.Body)
 	if err != nil {
 		log.Errorf("TestLogin failed with error: %v", err)
@@ -431,7 +444,7 @@ func TestLogin(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	status, err := server.TestLogin(testAuthConfig)
+	status, err := server.TestLogin(testAuthConfig, accessToken)
 	if err != nil {
 		log.Errorf("TestLogin GetProvider failed with error: %v", err)
 		if status == 0 {


### PR DESCRIPTION
Using /v1-autn/testlogin AD server settings can be changed, we need to
ensure with new settings same admin user can be searched

Also added serviceaccount pwd check while enabling access control.

https://github.com/rancher/rancher/issues/9641