### PR TITLE
Skip error for identities in savedIdentities required mode

### DIFF
--- a/providers/ldap/ldap_client.go
+++ b/providers/ldap/ldap_client.go
@@ -344,7 +344,8 @@ func (l *LClient) savedIdentities(allowedIdentities []string) ([]client.Identity
 		split := strings.SplitN(id, ":", 2)
 		identity, err := l.GetIdentity(split[1], split[0])
 		if err != nil {
-			return identityList, err
+			log.Errorf("Error in getting identity %v: %v", id, err)
+			continue
 		}
 		if !reflect.DeepEqual(identity, nilIdentity) {
 			identityList = append(identityList, identity)


### PR DESCRIPTION
In required mode, additional query is made during login to get all identities from
the allowed identity list. While getting these identities, the error can be ignored
as they don't belong to the user trying to login.

https://github.com/rancher/rancher/issues/10224
Validation test: https://github.com/rancher/validation-tests/pull/373
Corresponding cattle code https://github.com/rancher/cattle/blob/5a0f58013ba8ea185fe7f1246a4ab44646c16752/modules/caas/auth/src/main/java/io/cattle/platform/iaas/api/auth/integration/ldap/ad/ADIdentityProvider.java#L321