### PR TITLE
Refactor SAML

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 /dist
 *.swp
 /.trash-cache
+/rancher-auth-service

--- a/model/shibboleth_config.go
+++ b/model/shibboleth_config.go
@@ -1,6 +1,7 @@
 package model
 
 import (
+	"github.com/crewjam/saml"
 	"github.com/crewjam/saml/samlsp"
 	"github.com/rancher/go-rancher/v2"
 )
@@ -22,5 +23,13 @@ type ShibbolethConfig struct {
 	SPSelfSignedKeyFilePath  string
 	RancherAPIHost           string
 
-	SamlServiceProvider *samlsp.Middleware
+	SamlServiceProvider *RancherSamlServiceProvider
+}
+
+type RancherSamlServiceProvider struct {
+	ServiceProvider  saml.ServiceProvider
+	ClientState      samlsp.ClientState
+	RedirectBackPath string
+	RedirectBackBase string
+	XForwardedProto  string
 }

--- a/trash.conf
+++ b/trash.conf
@@ -13,7 +13,7 @@ github.com/rancher/go-rancher cc9af4572762fc6ae01f5f9bebbc359506c2f6dd
 github.com/tomnomnom/linkheader	0.1.0-5-g236df73
 golang.org/x/sys	a646d33
 github.com/urfave/cli v1.18.0
-github.com/crewjam/saml ce1532152fdecd37a8b9a059dc0129730174200d https://github.com/rancher/saml
+github.com/crewjam/saml 66ce2cf175ffc6c016b73c424fd12dc66cd9a2c2 https://github.com/rancher/saml
 github.com/crewjam/errset f78d65de925cf59a953184a376cbfe07cfe65e3d
 gopkg.in/ldap.v2 v2.5.0
 gopkg.in/asn1-ber.v1 v1.1

--- a/vendor/github.com/crewjam/saml/service_provider.go
+++ b/vendor/github.com/crewjam/saml/service_provider.go
@@ -87,7 +87,7 @@ type ServiceProvider struct {
 // issued by the IDP and the time it is received by ParseResponse. This is used
 // to prevent old responses from being replayed (while allowing for some clock
 // drift between the SP and IDP).
-const MaxIssueDelay = time.Second * 90
+const MaxIssueDelay = time.Second * 180
 
 // MaxClockSkew allows for leeway for clock skew between the IDP and SP when
 // validating assertions. It defaults to 180 seconds (matches shibboleth).


### PR DESCRIPTION
1. Remove use of SAML library's middleware, so that we don't use the token that
the library sets. This token set by the library can be big depending on size of
user's assertion returned by IdP. This token is set as a cookie and big cookies
cause problems as most browsers have a max limit of cookie size of 4096 bytes
2. Make the auth flow similar to 2.0
3. Make sure token cookie's secure flag is set depending on the request
rancherlabs/the-ranch#151
4. Restrict redirectBackBase to whitelisted domains (Host registration URL)
rancherlabs/the-ranch#150

https://github.com/rancher/rancher/issues/14756

rancherlabs/the-ranch#149

