### PR TITLE
Add setting to accept whitelisted redirect URLs

### DIFF
--- a/model/shibboleth_config.go
+++ b/model/shibboleth_config.go
@@ -27,9 +27,10 @@ type ShibbolethConfig struct {
 }
 
 type RancherSamlServiceProvider struct {
-	ServiceProvider  saml.ServiceProvider
-	ClientState      samlsp.ClientState
-	RedirectBackPath string
-	RedirectBackBase string
-	XForwardedProto  string
+	ServiceProvider   saml.ServiceProvider
+	ClientState       samlsp.ClientState
+	RedirectBackPath  string
+	RedirectBackBase  string
+	XForwardedProto   string
+	RedirectWhitelist string
 }


### PR DESCRIPTION
Based on a customer request we were strictly checking redirectBackBase to see if it matches the rancher api host or not. But it's possible to have different domains pointing to rancher host, in that case it would be necessary to whitelist them all. This PR adds a setting to provide a whitelist of domains to redirect to/from and compares redirectBackBase against each value in that setting
https://github.com/rancher/rancher/issues/16232

Cattle PR https://github.com/rancher/cattle/pull/3236