### PR TITLE
Delete relayState after obtaining redirect params

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@
 *.swp
 /.trash-cache
 /rancher-auth-service
+.idea/


### PR DESCRIPTION
Our ServeHTTP is same as library's ServeHTTP, except we call HandleSamlAssertion at the end
Our getPossibleRequestIDs is the same

HandleSamlAssertion corresponds to library's Authorize method.
The first part of HandleSamlAssertion gets the request URI from claims["uri"]
After that we get the redirectBackBase and redirectBackPath params